### PR TITLE
Prevent utility to show up when compiling, fixed 2018.4 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Use UIElements for Unity version 2019.3 going forward.
 - Toolbar search field at the top of the popup when using the UIElements version.
+
+## [1.1.1] - 2020-02-05
+### Fixed
+- Project not compiling when added to the packages folder of a project in 2018.4 or earlier
+- Disabled the utility when the editor is compiling, as that causes glitchy behaviour.

--- a/Editor/SceneViewGuiHandler.cs
+++ b/Editor/SceneViewGuiHandler.cs
@@ -7,7 +7,6 @@ namespace Nementic.SelectionUtility
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using UnityEditor;
     using UnityEngine;
     using Stopwatch = System.Diagnostics.Stopwatch;
@@ -115,7 +114,7 @@ namespace Nementic.SelectionUtility
 
                 var gameObjects = GameObjectsUnderMouse(current.mousePosition);
 
-                if (gameObjects.Count() > 0)
+                if (gameObjects.Count > 0)
                 {
                     Rect activatorRect = new Rect(current.mousePosition, Vector2.zero);
                     ShowSelectableGameObjectsPopup(activatorRect, gameObjects);

--- a/Editor/SceneViewGuiHandler.cs
+++ b/Editor/SceneViewGuiHandler.cs
@@ -107,7 +107,7 @@ namespace Nementic.SelectionUtility
 
             // Only show the selection menu if the click was short,
             // not if the user is holding to drag the SceneView camera.
-            if (elapsedMilliseconds < UserPreferences.ClickTimeout)
+            if (elapsedMilliseconds < UserPreferences.ClickTimeout && !EditorApplication.isCompiling)
             {
                 GUIUtility.hotControl = 0;
                 current.Use();

--- a/Editor/UIE_PopupWindow.cs
+++ b/Editor/UIE_PopupWindow.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the package root folder for more information.
 // Author: Chris Yarbrough
 
+#if UNITY_2019_3_OR_NEWER
+
 namespace Nementic.SelectionUtility
 {
     using UnityEditor;
@@ -13,7 +15,7 @@ namespace Nementic.SelectionUtility
     /// A popup-styled editor window which can be shown by providing
     /// an activator rect. This replicates the core functionality of
     /// <see cref="UnityEditor.PopupWindow"/>. Not to be confused with
-    /// the unluckily named <see cref="UnityEngine.UIElements.PopupWindow"/>, which 
+    /// the unluckily named <see cref="UnityEngine.UIElements.PopupWindow"/>, which
     /// only describes an element with similar styling.
     /// </summary>
     internal class UIE_PopupWindow : EditorWindow
@@ -54,3 +56,5 @@ namespace Nementic.SelectionUtility
         }
     }
 }
+
+#endif

--- a/Editor/UIE_SelectionPopup.cs
+++ b/Editor/UIE_SelectionPopup.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the package root folder for more information.
 // Author: Chris Yarbrough
 
+#if UNITY_2019_3_OR_NEWER
+
 namespace Nementic.SelectionUtility
 {
     using System;
@@ -225,3 +227,5 @@ namespace Nementic.SelectionUtility
         }
     }
 }
+
+#endif


### PR DESCRIPTION
When using the tool, I found that the behavioru when compiling was less then ideal - the window kept flashing in and out in a glitchy manner.

I fixed that by just checking if EditorApplication.IsCompiling, and skipping opening the popup if that's the case.

I also added #if UNITY_2019_3_OR_NEWER guards to the UI Elements based popups, to make it possible to edit this in 2018.4.