### PR TITLE
Fixed errors in the IMGUI version when objects gets deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Handle domain reload by serializing popup state.
 - Revert fix from v1.1.1 that blocks the utility while recompiling, since this is now supported.
+
+## [1.1.3] - 2020-02-20
+### Fixed
+- Errors when the objects shown in the popup was deleted by scripts or by scene loads in the IMGUI (2018.4) version

--- a/Editor/IMGUI_SelectionPopup.cs
+++ b/Editor/IMGUI_SelectionPopup.cs
@@ -285,7 +285,6 @@ namespace Nementic.SelectionUtility
 
         public override Vector2 GetWindowSize()
         {
-            int rows = 2 + options.Count;
             float height = RowHeight() * options.Count;
             height += EditorGUIUtility.standardVerticalSpacing;
 

--- a/Editor/IMGUI_SelectionPopup.cs
+++ b/Editor/IMGUI_SelectionPopup.cs
@@ -165,6 +165,16 @@ namespace Nementic.SelectionUtility
 
         public override void OnGUI(Rect rect)
         {
+            for (int i = options.Count - 1; i >= 0; i--)
+                if (options[i] == null)
+                    options.RemoveAt(i);
+
+            if (options.Count == 0)
+            {
+                ClosePopup();
+                return;
+            }
+
             Event current = Event.current;
 
             scroll = GUI.BeginScrollView(rect, scroll, contentRect, GUIStyle.none, GUI.skin.verticalScrollbar);
@@ -191,6 +201,13 @@ namespace Nementic.SelectionUtility
 
             if (current.type == EventType.MouseMove)
                 editorWindow.Repaint();
+        }
+
+        private void ClosePopup()
+        {
+            if (editorWindow)
+                editorWindow.Close();
+            GUIUtility.ExitGUI();
         }
 
         private void DrawSplitter(Rect rect)
@@ -238,9 +255,7 @@ namespace Nementic.SelectionUtility
                     ToggleSelectedObject(target);
                 }
 
-                if (base.editorWindow)
-                    base.editorWindow.Close();
-                GUIUtility.ExitGUI();
+                ClosePopup();
             }
 
             if (target == null)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Nementic Selection Utility is a small Unity tool which facilitates selecting
 ![Preview: Selection Utility in the SceneView](Documentation~/Preview.png)
 
 ## Setup
-This tool has no dependencies other than the Unity editor itself and becomes available as soon as it is installed. The currently verified Unity versions are 2019.1 - 2019.3.
+This tool has no dependencies other than the Unity editor itself and becomes available as soon as it is installed. The currently verified Unity versions are 2018.4 - 2019.3.
 
 ## Usage
 Right-click over GameObjects in the SceneView to show a dropdown of all objects that can be selected. The list is sorted by depth from front to back and displays icons for each component on a selectable GameObject. Left-click an item in the list to select it.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "com.nementic.selection-utility",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "displayName": "Selection Utility",
   "description": "Facilitates selecting GameObjects in the SceneView by displaying a context menu with all objects currently under the mouse cursor as a dropdown similar to how layers in common image editing software can be selected.",
-  "unity": "2019.1",
+  "unity": "2018.4",
   "keywords": [
     "Nementic",
     "Selection",


### PR DESCRIPTION
There's a bug in the 2018.4 version where the popup closes with exceptions when the target objects gets deleted. That usually happens for me when I open a new scene, but could also happen if some editor script deletes the object, or if the tool's used in play mode.

This PR handles that by simply removing options that are == null on top of OnGUI, and closing the popup when there's none left.

I wanted to fix the same bug in the UI Elements version, but I'm not familiar enough with the API to figure out how to do that in the time I had. The bug's also not as bad there, the options stay around, and simply don't do anything instead of erroring out.

I also change the README and the package.json to specify that the minimum supported version is 2018.4 instead of 2019.1, since I've used it a bunch in 2018.4 and haven't had any major issues. Feel free to ping me if you get a bug report for 2018.4, I can support that since I'll be working on that Untiy version for at least a few months more.